### PR TITLE
Fix Battery percentage source to be updated live

### DIFF
--- a/widgets/percentage.py
+++ b/widgets/percentage.py
@@ -4,14 +4,12 @@ from widget_config_item import ConfigItemType as ConfigType
 from font_loader import get_fonts
 import psutil
 
-battery = psutil.sensors_battery()
-
 class Widget(TextBasedWidget):
     name = "Percentage"
 
     percentage_sources = {
         "None": lambda w: 0,
-        "Battery": lambda w: battery.percent,
+        "Battery": lambda w: psutil.sensors_battery().percent,
         "CPU Usage": lambda w: psutil.cpu_percent(0),
         "RAM Usage": lambda w: psutil.virtual_memory().percent
     }


### PR DESCRIPTION
I just realized that the same bug was in the percentage widget too... same issue as the fill-source bug from https://github.com/DedFishy/FWMM/pull/3